### PR TITLE
Fixed typo Recognised to Recognized for PR#542.

### DIFF
--- a/Damselfly.Core.DbModels/Models/API Models/Statistics.cs
+++ b/Damselfly.Core.DbModels/Models/API Models/Statistics.cs
@@ -11,7 +11,7 @@ public class Statistics
     public int PendingKeywordOps { get; set; }
     public int PendingKeywordImages { get; set; }
     public long TotalImagesSizeBytes { get; set; }
-    public int ObjectsRecognised { get; set; }
+    public int ObjectsRecognized { get; set; }
     public int PeopleFound { get; set; }
     public int PeopleIdentified { get; set; }
     public string OperatingSystem { get; set; }

--- a/Damselfly.Core/Services/StatisticsService.cs
+++ b/Damselfly.Core/Services/StatisticsService.cs
@@ -38,7 +38,7 @@ public class StatisticsService
             TotalImagesSizeBytes = await db.Images.SumAsync(x => (long)x.FileSizeBytes),
             PeopleFound = await db.People.CountAsync(),
             PeopleIdentified = await db.People.Where(x => x.Name != "Unknown").CountAsync(),
-            ObjectsRecognised = await db.ImageObjects.CountAsync(),
+            ObjectsRecognized = await db.ImageObjects.CountAsync(),
             PendingAIScans = await db.ImageMetaData.Where(x => !x.AILastUpdated.HasValue).CountAsync(),
             PendingThumbs = await db.ImageMetaData.Where(x => !x.ThumbLastUpdated.HasValue).CountAsync(),
             PendingImages = await db.Images.Where(x => x.MetaData == null || x.LastUpdated > x.MetaData.LastUpdated)

--- a/Damselfly.Web.Client/Shared/Stats.razor
+++ b/Damselfly.Web.Client/Shared/Stats.razor
@@ -51,7 +51,7 @@
                 <td>Tags/Keywords:</td><td>@statistics.TotalTags</td>
             </tr>
             <tr>
-                <td>Recognised Objects:</td><td>@statistics.ObjectsRecognised</td>
+                <td>Recognized Objects:</td><td>@statistics.ObjectsRecognized</td>
             </tr>
             <tr>
                 <td>Faces:</td><td>@statistics.PeopleFound</td>


### PR DESCRIPTION
Replaced "Recognised" with "Recognized"

```$ grep -R Recognised ./*
./Damselfly.Core/Services/StatisticsService.cs:            ObjectsRecognised = await db.ImageObjects.CountAsync(),
./Damselfly.Core.DbModels/Models/API Models/Statistics.cs:    public int ObjectsRecognised { get; set; }
./Damselfly.Web.Client/Shared/Stats.razor:                <td>Recognised Objects:</td><td>@statistics.ObjectsRecognised</td>
```

```$ grep -R Recognized ./*
./Damselfly.Core/Services/StatisticsService.cs:            ObjectsRecognized = await db.ImageObjects.CountAsync(),
./Damselfly.Core.DbModels/Models/API Models/Statistics.cs:    public int ObjectsRecognized { get; set; }
./Damselfly.Web.Client/Shared/Stats.razor:                <td>Recognized Objects:</td><td>@statistics.ObjectsRecognized</td>
```